### PR TITLE
add null check to protect against null arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ module.exports = function(url) {
   var auth_part = '';
   var query_string_part = '';
   var dbName = 'admin';
-
-  if (url.indexOf("/") < 0) 
+  // if url supplied is null it defaults to localhost
+  if (!url || url.indexOf("/") < 0)
     url = '127.0.0.1/' + url;
   // Must start with mongodb
   if(url.indexOf("mongodb://") != 0)


### PR DESCRIPTION
Hi we've experienced that in some other libraries using this as a dependency, they expect (usually in tests) that you can provide nothing as a url, and that will default to localhost. I propose this change to enable that possibility, or at least throw an error or something to get out of a null reference exception. 
